### PR TITLE
Fix FBI @wanted API URL for JSON data retrieval

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from lib.colors import red,white,green,reset
 class Wanted:
     def __init__(self,args):
         if args.wanted:
-        	self.api = f'https://api.fbi.gov/@wanted'
+        	self.api = f'https://api.fbi.gov/@wanted?pageSize=20&page=1&sort_on=modified&sort_order=desc'
         else:
         	self.api = f'https://api.fbi.gov/@wanted-person/{args.wanted_person}'
         	


### PR DESCRIPTION
The previous URL (https://api.fbi.gov/@wanted) unexpectedly returned HTML data instead of the expected JSON format. To address this issue, the URL has been updated based on the specifications provided in the FBI API documentation.

The updated API URL is: https://api.fbi.gov/@wanted?pageSize=20&page=1&sort_on=modified&sort_order=desc

The pageSize parameter in the URL controls the number of entries per page and can be modified using user arguments. I wasn't able to do that because precompiled python code contains arguments code

I pasted the SS below!
![2023-05-11 19_43_32-VirtualBoxVM](https://github.com/rly0nheart/fbi-mostwanted/assets/93365275/d648ecd4-5e67-4b71-a4cb-70b3ad38ffbe)
![2023-05-11 19_47_06-VirtualBoxVM](https://github.com/rly0nheart/fbi-mostwanted/assets/93365275/a6310705-2520-4875-8e57-d5b4dc324ff5)
![2023-05-11 19_49_31-VirtualBoxVM](https://github.com/rly0nheart/fbi-mostwanted/assets/93365275/a5943018-fb66-4473-942b-d2278e6fcbf6)
![2023-05-11 20_02_59-VirtualBoxVM](https://github.com/rly0nheart/fbi-mostwanted/assets/93365275/4e098aae-b973-48e0-adb1-9d18d0d234f0)
